### PR TITLE
Shave 2 more characters off

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <link rel="icon" href="data:,">
 <title>very·united</title>
 <canvas width="150"></canvas><br>
-<a href="1kb.html">[about]</a>
+<a href="1kb.html">about</a>
 <script>
     function d() {
         var ctx = document.querySelector("canvas").getContext?.("2d")


### PR DESCRIPTION
The undeletable `x-cache` header will return:
- "Hit from Cloudfront"
- "Miss from Cloudfront"

But turns out, there's a third variant:
- "RefreshHit from Cloudfront"

which brings the page over the 1023 byte limit. So, remove 2 more chars: `[` and `]` 😭